### PR TITLE
Fix CircularMinutePicker returning 60

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -418,7 +418,7 @@ class CircularMinutePicker(CircularNumberPicker):
     def __init__(self, **kw):
         super(CircularMinutePicker, self).__init__(**kw)
         self.min = 0
-        self.max = 60
+        self.max = 59
         self.multiples_of = 5
         self.number_format_string = "{:02d}"
         self.direction = "cw"


### PR DESCRIPTION
Sometimes the widget raises this exception when selecting 59 minutes.

`../circulardatetimepicker/__init__.py", line 536, in _get_time
     return datetime.time(*self.time_list)
 ValueError: minute must be in 0..59`

It is caused by CircularMInutePicker returning 60, the quick fix is to set its max to 59, it works and it's still possible to select 59 minutes.... but the source of the bug is CircularNumberPicker
