### PR TITLE
Enforce CircularNumberPicker max

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -409,7 +409,7 @@ class CircularNumberPicker(CircularLayout):
         elif angle > 2*pi:
             angle -= 2*pi
 
-        return int(angle / quota) + self.min
+        return min(int(angle / quota) + self.min, self.max-1)
 
 class CircularMinutePicker(CircularNumberPicker):
     """:class:`CircularNumberPicker` implementation for minutes.
@@ -418,7 +418,7 @@ class CircularMinutePicker(CircularNumberPicker):
     def __init__(self, **kw):
         super(CircularMinutePicker, self).__init__(**kw)
         self.min = 0
-        self.max = 59
+        self.max = 60
         self.multiples_of = 5
         self.number_format_string = "{:02d}"
         self.direction = "cw"


### PR DESCRIPTION
Hi

I have done a few more test and it appears that the source of the problem comes from rounding, so changing the max to 59 works but makes harder to select 59 minutes. So the better solution is to enforce the max at CircularNumberPicker.

The other problem is the widget is not python3 compatible because it uses xrange, I have left it as it is but It can be fixed with just this import:

`from past.builtins import xrange`