### PR TITLE
Fixed format of color for number labels and center dot

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -652,7 +652,7 @@ class CircularTimePicker(BoxLayout):
         picker.pos = container.pos
         picker.size = container.size
         picker.selector_color = self.selector_color
-        picker.color = self.color
+        picker.color = self.color + [1]
         picker.selector_alpha = self.selector_alpha
 
         if noanim:


### PR DESCRIPTION
Related to issue 9:
Not super sure if you wanted a way to change the opacity of the numbers, but based on a new change, color requires an alpha value as well. If your intention is to have the number the full color, this pull should fix the problem.